### PR TITLE
Command with subcommands and arguments

### DIFF
--- a/docsite/source/commands-with-subcommands-&-params.md
+++ b/docsite/source/commands-with-subcommands-&-params.md
@@ -1,0 +1,85 @@
+---
+title: Commands with subcommands and params
+layout: gem-single
+name: dry-cli
+---
+
+There is a way to register command with arguments, options and subcommands.
+
+This helps to implement complex nested logic.
+
+Arguments and options can be defined for parent both commands and child commands.
+
+**Note:** If you call a command with an argument equal to the name of the subcommand, it will call the subcommand instead of the parent command.
+
+```ruby
+#!/usr/bin/env ruby
+require "bundler/setup"
+require "dry/cli"
+
+module Foo
+  module CLI
+    module Commands
+      extend Dry::CLI::Registry
+
+      class Account < Dry::CLI::Command
+        desc 'Information about account'
+
+        argument :format, default: "short", values: %w[long short], desc: "Output format"
+
+        def call(**options)
+          puts "Information about account in #{options.fetch(:format)} format."
+        end
+
+        class Users < Dry::CLI::Command
+          desc 'Information about account users'
+
+          def call(**_options)
+            puts "Information about account users."
+          end
+        end
+      end
+
+      register "account", Account
+      register "account users", Account::Users
+    end
+  end
+end
+
+Dry::CLI.new(Foo::CLI::Commands).call
+```
+```
+$ foo account -h
+Command:
+  foo account
+
+Usage:
+  foo account [FORMAT] | foo account SUBCOMMAND
+
+Description:
+  Information about account
+
+Subcommands:
+  users                         	# Information about account users
+
+Arguments:
+  FORMAT              	# Output format: (long/short)
+
+Options:
+  --help, -h                      	# Print this help
+```
+```sh
+$ foo account
+# Information about account in short format.
+```
+
+```sh
+$ foo account long
+# Information about account in long format.
+```
+
+```sh
+$ foo account users
+# Information about account users.
+```
+

--- a/docsite/source/index.html.md
+++ b/docsite/source/index.html.md
@@ -10,6 +10,7 @@ sections:
   - arguments
   - options
   - variadic-arguments
+  - commands-with-subcommands-&-params
   - callbacks
   - file-utilities
 ---

--- a/lib/dry/cli/banner.rb
+++ b/lib/dry/cli/banner.rb
@@ -22,6 +22,7 @@ module Dry
           command_name(full_command_name),
           command_name_and_arguments(command, full_command_name),
           command_description(command),
+          command_subcommands(command),
           command_arguments(command),
           command_options(command),
           command_examples(command, full_command_name)
@@ -37,7 +38,11 @@ module Dry
       # @since 0.1.0
       # @api private
       def self.command_name_and_arguments(command, name)
-        "\nUsage:\n  #{name}#{arguments(command)}"
+        usage = "\nUsage:\n  #{name}#{arguments(command)}"
+
+        return usage + " | #{name} SUBCOMMAND" unless command.subcommands.empty?
+
+        usage
       end
 
       # @since 0.1.0
@@ -54,6 +59,12 @@ module Dry
         return if command.description.nil?
 
         "\nDescription:\n  #{command.description}"
+      end
+
+      def self.command_subcommands(command)
+        return if command.subcommands.empty?
+
+        "\nSubcommands:\n#{build_subcommands_list(command.subcommands)}"
       end
 
       # @since 0.1.0
@@ -119,6 +130,12 @@ module Dry
 
         result << "  --#{'help, -h'.ljust(30)}\t# Print this help"
         result.join("\n")
+      end
+
+      def self.build_subcommands_list(subcommands)
+        subcommands.map do |subcommand_name, subcommand|
+          "  #{subcommand_name.ljust(30)}\t# #{subcommand.command.description}"
+        end.join("\n")
       end
     end
   end

--- a/lib/dry/cli/command.rb
+++ b/lib/dry/cli/command.rb
@@ -28,6 +28,7 @@ module Dry
           base.class_eval do
             @description  = nil
             @examples     = Concurrent::Array.new
+            @subcommands  = Concurrent::Array.new
             @arguments    = Concurrent::Array.new
             @options      = Concurrent::Array.new
           end
@@ -48,6 +49,10 @@ module Dry
         # @since 0.1.0
         # @api private
         attr_reader :options
+
+        # @since 0.6.0
+        # @api private
+        attr_accessor :subcommands
       end
 
       # Set the description of the command
@@ -340,6 +345,10 @@ module Dry
         arguments.reject(&:required?)
       end
 
+      def self.subcommands
+        subcommands
+      end
+
       extend Forwardable
 
       delegate %i[
@@ -351,6 +360,7 @@ module Dry
         default_params
         required_arguments
         optional_arguments
+        subcommands
       ] => 'self.class'
     end
   end

--- a/lib/dry/cli/command_registry.rb
+++ b/lib/dry/cli/command_registry.rb
@@ -37,12 +37,16 @@ module Dry
         node   = @root
         args   = []
         names  = []
+        valid_leaf = nil
         result = LookupResult.new(node, args, names, node.leaf?)
 
         arguments.each_with_index do |token, i|
           tmp = node.lookup(token)
 
-          if tmp.nil?
+          if tmp.nil? && valid_leaf
+            result = valid_leaf
+            break
+          elsif tmp.nil?
             result = LookupResult.new(node, args, names, false)
             break
           elsif tmp.leaf?
@@ -50,7 +54,8 @@ module Dry
             names  = arguments[0..i]
             node   = tmp
             result = LookupResult.new(node, args, names, true)
-            break
+            valid_leaf = result
+            break unless tmp.children?
           else
             names  = arguments[0..i]
             node   = tmp
@@ -138,6 +143,10 @@ module Dry
         # @api private
         def leaf?
           !command.nil?
+        end
+
+        def children?
+          !children.empty?
         end
       end
 

--- a/lib/dry/cli/command_registry.rb
+++ b/lib/dry/cli/command_registry.rb
@@ -123,6 +123,7 @@ module Dry
         # @api private
         def leaf!(command)
           @command = command
+          command.subcommands = children
         end
 
         # @since 0.1.0

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -62,7 +62,7 @@ module Dry
             usage = "\nUsage: \"#{command_name} #{command.required_arguments.map(&:description_name).join(' ')} | #{command_name} SUBCOMMAND\"" # rubocop:disable Metrics/LineLength
           end
 
-          if parsed_required_params_values.empty? # rubocop:disable Style/GuardClause
+          if parsed_required_params_values.empty?
             return Result.failure("ERROR: \"#{command_name}\" was called with no arguments#{usage}") # rubocop:disable Metrics/LineLength
           else
             return Result.failure("ERROR: \"#{command_name}\" was called with arguments #{parsed_required_params_values}#{usage}") # rubocop:disable Metrics/LineLength

--- a/lib/dry/cli/parser.rb
+++ b/lib/dry/cli/parser.rb
@@ -54,13 +54,18 @@ module Dry
 
         unless all_required_params_satisfied
           parsed_required_params_values = parsed_required_params.values.compact
+          command_name = full_command_name(names)
 
-          usage = "\nUsage: \"#{full_command_name(names)} #{command.required_arguments.map(&:description_name).join(' ')}\"" # rubocop:disable Metrics/LineLength
+          if command.subcommands.empty?
+            usage = "\nUsage: \"#{full_command_name(names)} #{command.required_arguments.map(&:description_name).join(' ')}\"" # rubocop:disable Metrics/LineLength
+          else
+            usage = "\nUsage: \"#{command_name} #{command.required_arguments.map(&:description_name).join(' ')} | #{command_name} SUBCOMMAND\"" # rubocop:disable Metrics/LineLength
+          end
 
           if parsed_required_params_values.empty? # rubocop:disable Style/GuardClause
-            return Result.failure("ERROR: \"#{full_command_name(names)}\" was called with no arguments#{usage}") # rubocop:disable Metrics/LineLength
+            return Result.failure("ERROR: \"#{command_name}\" was called with no arguments#{usage}") # rubocop:disable Metrics/LineLength
           else
-            return Result.failure("ERROR: \"#{full_command_name(names)}\" was called with arguments #{parsed_required_params_values}#{usage}") # rubocop:disable Metrics/LineLength
+            return Result.failure("ERROR: \"#{command_name}\" was called with arguments #{parsed_required_params_values}#{usage}") # rubocop:disable Metrics/LineLength
           end
         end
 

--- a/lib/dry/cli/usage.rb
+++ b/lib/dry/cli/usage.rb
@@ -12,6 +12,7 @@ module Dry
       # @since 0.1.0
       # @api private
       SUBCOMMAND_BANNER = ' [SUBCOMMAND]'
+      ROOT_COMMAND_WITH_SUBCOMMANDS_BANNER = ' [ARGUMENT|SUBCOMMAND]'
 
       # @since 0.1.0
       # @api private
@@ -30,7 +31,9 @@ module Dry
       def self.commands_and_arguments(result)
         max_length = 0
         ret        = commands(result).each_with_object({}) do |(name, node), memo|
-          args = if node.leaf?
+          args = if node.command && node.leaf? && node.children?
+                   ROOT_COMMAND_WITH_SUBCOMMANDS_BANNER
+                 elsif node.leaf?
                    arguments(node.command)
                  else
                    SUBCOMMAND_BANNER

--- a/spec/integration/rendering_spec.rb
+++ b/spec/integration/rendering_spec.rb
@@ -9,20 +9,21 @@ RSpec.describe 'Rendering' do
     expected = <<~DESC
       Commands:
         foo assets [SUBCOMMAND]
-        foo callbacks DIR                      # Command with callbacks
-        foo console                            # Starts Foo console
+        foo callbacks DIR                                          # Command with callbacks
+        foo console                                                # Starts Foo console
         foo db [SUBCOMMAND]
         foo destroy [SUBCOMMAND]
-        foo exec TASK [DIRS]                   # Execute a task
+        foo exec TASK [DIRS]                                       # Execute a task
         foo generate [SUBCOMMAND]
         foo greeting [RESPONSE]
-        foo hello                              # Print a greeting
-        foo new PROJECT                        # Generate a new Foo project
-        foo routes                             # Print routes
-        foo server                             # Start Foo server (only for development)
+        foo hello                                                  # Print a greeting
+        foo new PROJECT                                            # Generate a new Foo project
+        foo root-command [ARGUMENT|SUBCOMMAND]                     # Root command with arguments and subcommands
+        foo routes                                                 # Print routes
+        foo server                                                 # Start Foo server (only for development)
         foo sub [SUBCOMMAND]
         foo variadic [SUBCOMMAND]
-        foo version                            # Print Foo version
+        foo version                                                # Print Foo version
     DESC
 
     expect(stderr).to eq(expected)

--- a/spec/integration/single_command_spec.rb
+++ b/spec/integration/single_command_spec.rb
@@ -54,4 +54,28 @@ RSpec.describe 'Single command' do
       )
     end
   end
+
+  context 'root command with arguments and subcommands' do
+    it 'with arguments' do
+      output = `foo root-command "hello world"`
+
+      expected = <<~DESC
+        I'm a root-command argument:hello world
+        I'm a root-command option:
+      DESC
+
+      expect(output).to eq(expected)
+    end
+
+    it 'with options' do
+      output = `foo root-command "hello world" --root-command-option="bye world"`
+
+      expected = <<~DESC
+        I'm a root-command argument:hello world
+        I'm a root-command option:bye world
+      DESC
+
+      expect(output).to eq(expected)
+    end
+  end
 end

--- a/spec/integration/subcommands_spec.rb
+++ b/spec/integration/subcommands_spec.rb
@@ -32,4 +32,29 @@ RSpec.describe 'Subcommands' do
       expect(output).to eq(expected)
     end
   end
+
+  context 'works with root command subcommands' do
+    it 'with params' do
+      output = `foo root-command sub-command "hello world"`
+
+      expected = <<~DESC
+        I'm a root-command sub-command argument:hello world
+        I'm a root-command sub-command option:
+      DESC
+
+      expect(output).to eq(expected)
+    end
+
+    it 'with options' do
+      option = '--root-command-sub-command-option="bye world"'
+      output = `foo root-command sub-command "hello world" #{option}`
+
+      expected = <<~DESC
+        I'm a root-command sub-command argument:hello world
+        I'm a root-command sub-command option:bye world
+      DESC
+
+      expect(output).to eq(expected)
+    end
+  end
 end

--- a/spec/support/fixtures/foo
+++ b/spec/support/fixtures/foo
@@ -397,6 +397,30 @@ module Foo
           end
         end
       end
+
+      class RootCommand < Dry::CLI::Command
+        desc 'Root command with arguments and subcommands'
+        argument :root_command_argument, desc: 'Root command argument', required: true
+        option :root_command_option, desc: 'Root command option'
+
+        def call(**params)
+          puts "I'm a root-command argument:#{params[:root_command_argument]}"
+          puts "I'm a root-command option:#{params[:root_command_option]}"
+        end
+      end
+
+      module RootCommands
+        class SubCommand < Dry::CLI::Command
+          desc 'Root command sub command'
+          argument :root_command_sub_command_argument, desc: 'Root command sub command argument', required: true
+          option :root_command_sub_command_option, desc: 'Root command sub command option'
+
+          def call(**params)
+            puts "I'm a root-command sub-command argument:#{params[:root_command_sub_command_argument]}"
+            puts "I'm a root-command sub-command option:#{params[:root_command_sub_command_option]}"
+          end
+        end
+      end
     end
   end
 end
@@ -437,6 +461,8 @@ Foo::CLI::Commands.register 'exec',    Foo::CLI::Commands::Exec
 Foo::CLI::Commands.register 'hello',       Foo::CLI::Commands::Hello
 Foo::CLI::Commands.register 'greeting',    Foo::CLI::Commands::Greeting
 Foo::CLI::Commands.register 'sub command', Foo::CLI::Commands::Sub::Command
+Foo::CLI::Commands.register 'root-command', Foo::CLI::Commands::RootCommand
+Foo::CLI::Commands.register 'root-command sub-command', Foo::CLI::Commands::RootCommands::SubCommand
 
 Foo::CLI::Commands.register 'variadic default',                    Foo::CLI::Commands::VariadicArguments
 Foo::CLI::Commands.register 'variadic with-mandatory',             Foo::CLI::Commands::MandatoryAndVariadicArguments

--- a/spec/support/fixtures/shared_commands.rb
+++ b/spec/support/fixtures/shared_commands.rb
@@ -425,6 +425,17 @@ module Commands
         puts "I'm a root-command sub-command option:#{params[:root_command_sub_command_option]}"
       end
     end
+
+    class SubCommand2 < Dry::CLI::Command
+      desc 'Root command sub command'
+      argument :root_command_sub_command_argument, desc: 'Root command sub command argument', required: true
+      option :root_command_sub_command_option, desc: 'Root command sub command option'
+
+      def call(**params)
+        puts "I'm a root-command sub-command argument:#{params[:root_command_sub_command_argument]}"
+        puts "I'm a root-command sub-command option:#{params[:root_command_sub_command_option]}"
+      end
+    end
   end
 end
 

--- a/spec/support/fixtures/shared_commands.rb
+++ b/spec/support/fixtures/shared_commands.rb
@@ -402,6 +402,30 @@ module Commands
       end
     end
   end
+
+  class RootCommand < Dry::CLI::Command
+    desc 'Root command with arguments and subcommands'
+    argument :root_command_argument, desc: 'Root command argument', required: true
+    option :root_command_option, desc: 'Root command option'
+
+    def call(**params)
+      puts "I'm a root-command argument:#{params[:root_command_argument]}"
+      puts "I'm a root-command option:#{params[:root_command_option]}"
+    end
+  end
+
+  module RootCommands
+    class SubCommand < Dry::CLI::Command
+      desc 'Root command sub command'
+      argument :root_command_sub_command_argument, desc: 'Root command sub command argument', required: true
+      option :root_command_sub_command_option, desc: 'Root command sub command option'
+
+      def call(**params)
+        puts "I'm a root-command sub-command argument:#{params[:root_command_sub_command_argument]}"
+        puts "I'm a root-command sub-command option:#{params[:root_command_sub_command_option]}"
+      end
+    end
+  end
 end
 
 module Webpack

--- a/spec/support/fixtures/with_block.rb
+++ b/spec/support/fixtures/with_block.rb
@@ -18,6 +18,8 @@ WithBlock = Dry::CLI.new do |cli|
   cli.register 'hello',       Commands::Hello
   cli.register 'greeting',    Commands::Greeting
   cli.register 'sub command', Commands::Sub::Command
+  cli.register 'root-command', Commands::RootCommand
+  cli.register 'root-command sub-command', Commands::RootCommands::SubCommand
 
   cli.register 'options-with-aliases',                Commands::OptionsWithAliases
   cli.register 'variadic default',                    Commands::VariadicArguments

--- a/spec/support/fixtures/with_registry.rb
+++ b/spec/support/fixtures/with_registry.rb
@@ -48,6 +48,9 @@ module Foo
       register 'hello',       ::Commands::Hello
       register 'greeting',    ::Commands::Greeting
       register 'sub command', ::Commands::Sub::Command
+      register 'root-command', ::Commands::RootCommand
+      register 'root-command sub-command', ::Commands::RootCommands::SubCommand
+
 
       register 'options-with-aliases',                ::Commands::OptionsWithAliases
       register 'variadic default',                    ::Commands::VariadicArguments

--- a/spec/support/fixtures/with_registry.rb
+++ b/spec/support/fixtures/with_registry.rb
@@ -51,7 +51,6 @@ module Foo
       register 'root-command', ::Commands::RootCommand
       register 'root-command sub-command', ::Commands::RootCommands::SubCommand
 
-
       register 'options-with-aliases',                ::Commands::OptionsWithAliases
       register 'variadic default',                    ::Commands::VariadicArguments
       register 'variadic with-mandatory',             ::Commands::MandatoryAndVariadicArguments        # rubocop:disable Metrics/LineLength

--- a/spec/support/fixtures/with_zero_arity_block.rb
+++ b/spec/support/fixtures/with_zero_arity_block.rb
@@ -18,6 +18,8 @@ WithZeroArityBlock = Dry.CLI do
   register 'hello',       Commands::Hello
   register 'greeting',    Commands::Greeting
   register 'sub command', Commands::Sub::Command
+  register 'root-command', Commands::RootCommand
+  register 'root-command sub-command', Commands::RootCommands::SubCommand
 
   register 'options-with-aliases',                Commands::OptionsWithAliases
   register 'variadic default',                    Commands::VariadicArguments

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -203,93 +203,91 @@ RSpec.shared_examples 'Commands' do |cli|
   end
 
   context 'works with command with arguments and subcommands' do
-    # it 'shows help' do
-    #   output = capture_output { cli.call(arguments: %w[root-command -h]) }
-    #   expected = <<~DESC
-    #     Command:
-    #       rspec root-command
-    #
-    #     Usage:
-    #       rspec root-command [ARGUMENT|SUBCOMMAND]
-    #
-    #     Description:
-    #       Root command with arguments and subcommands
-    #
-    #     Subcommands:
-    #       Root command sub command
-    #
-    #     Arguments:
-    #       ROOT_COMMAND_ARGUMENT	# REQUIRED Root command argument
-    #
-    #     Options:
-    #       --root-command-option=VALUE     	# Root command option
-    #       --help, -h                      	# Print this help
-    #   DESC
-    #
-    #   expect(output).to eq(expected)
-    #
-    #   output = capture_output { cli.call(arguments: %w[root-command sub-command --help]) }
-    #   expect(output).to eq(expected)
-    # end
+    it 'shows help' do
+      output = capture_output { cli.call(arguments: %w[root-command -h]) }
+      expected = <<~DESC
+        Command:
+          #{cmd} root-command
 
-    # context 'works with params' do
-    #   it 'without params' do
-    #     error = capture_error { cli.call(arguments: %w[root-command sub-command]) }
-    #     expected = <<~DESC
-    #       ERROR: "rspec root-command sub-command" was called with no arguments
-    #       Usage: "rspec root-command sub-command ROOT_COMMAND_SUB_COMMAND_ARGUMENT"
-    #     DESC
-    #
-    #     expect(error).to eq(expected)
-    #   end
+        Usage:
+          #{cmd} root-command ROOT_COMMAND_ARGUMENT | #{cmd} root-command SUBCOMMAND
 
-    #   it 'with params' do
-    #     output = capture_output {
-    #       cli.call(arguments: ['root-command', 'sub-command', '"hello world"'])
-    #     }
-    #     expected = <<~DESC
-    #       I'm a root-command sub-command argument:"hello world"
-    #       I'm a root-command sub-command option:
-    #     DESC
-    #
-    #     expect(output).to eq(expected)
-    #   end
-    #
-    #   it 'with option using space' do
-    #     output = capture_output {
-    #       cli.call(arguments: [
-    #         'root-command',
-    #         'sub-command',
-    #         '"hello world"',
-    #         '--root-command-sub-command-option',
-    #         '"bye world"'
-    #       ])
-    #     }
-    #     expected = <<~DESC
-    #       I'm a root-command sub-command argument:"hello world"
-    #       I'm a root-command sub-command option:"bye world"
-    #     DESC
-    #
-    #     expect(output).to eq(expected)
-    #   end
-    #
-    #   it 'with option using equal sign' do
-    #     output = capture_output {
-    #       cli.call(arguments: [
-    #         'root-command',
-    #         'sub-command',
-    #         '"hello world"',
-    #         '--root-command-sub-command-option="bye world"'
-    #       ])
-    #     }
-    #     expected = <<~DESC
-    #       I'm a root-command sub-command argument:"hello world"
-    #       I'm a root-command sub-command option:"bye world"
-    #     DESC
-    #
-    #     expect(output).to eq(expected)
-    #   end
-    # end
+        Description:
+          Root command with arguments and subcommands
+
+        Subcommands:
+          sub-command                   	# Root command sub command
+
+        Arguments:
+          ROOT_COMMAND_ARGUMENT	# REQUIRED Root command argument
+
+        Options:
+          --root-command-option=VALUE     	# Root command option
+          --help, -h                      	# Print this help
+      DESC
+
+      expect(output).to eq(expected)
+
+      output = capture_output { cli.call(arguments: %w[root-command --help]) }
+      expect(output).to eq(expected)
+    end
+
+    context 'works with params' do
+      it 'without params' do
+        error = capture_error { cli.call(arguments: %w[root-command]) }
+        expected = <<~DESC
+          ERROR: "rspec root-command" was called with no arguments
+          Usage: "rspec root-command ROOT_COMMAND_ARGUMENT | rspec root-command SUBCOMMAND"
+        DESC
+
+        expect(error).to eq(expected)
+      end
+
+      it 'with params' do
+        output = capture_output {
+          cli.call(arguments: ['root-command', '"hello world"'])
+        }
+        expected = <<~DESC
+          I'm a root-command argument:"hello world"
+          I'm a root-command option:
+        DESC
+
+        expect(output).to eq(expected)
+      end
+
+      it 'with option using space' do
+        output = capture_output {
+          cli.call(arguments: [
+            'root-command',
+            '"hello world"',
+            '--root-command-option',
+            '"bye world"'
+          ])
+        }
+        expected = <<~DESC
+          I'm a root-command argument:"hello world"
+          I'm a root-command option:"bye world"
+        DESC
+
+        expect(output).to eq(expected)
+      end
+
+      it 'with option using equal sign' do
+        output = capture_output {
+          cli.call(arguments: [
+            'root-command',
+            '"hello world"',
+            '--root-command-option="bye world"'
+          ])
+        }
+        expected = <<~DESC
+          I'm a root-command argument:"hello world"
+          I'm a root-command option:"bye world"
+        DESC
+
+        expect(output).to eq(expected)
+      end
+    end
   end
 end
 # rubocop:enable Metrics/LineLength

--- a/spec/support/shared_examples/commands.rb
+++ b/spec/support/shared_examples/commands.rb
@@ -201,5 +201,95 @@ RSpec.shared_examples 'Commands' do |cli|
       end
     end
   end
+
+  context 'works with command with arguments and subcommands' do
+    # it 'shows help' do
+    #   output = capture_output { cli.call(arguments: %w[root-command -h]) }
+    #   expected = <<~DESC
+    #     Command:
+    #       rspec root-command
+    #
+    #     Usage:
+    #       rspec root-command [ARGUMENT|SUBCOMMAND]
+    #
+    #     Description:
+    #       Root command with arguments and subcommands
+    #
+    #     Subcommands:
+    #       Root command sub command
+    #
+    #     Arguments:
+    #       ROOT_COMMAND_ARGUMENT	# REQUIRED Root command argument
+    #
+    #     Options:
+    #       --root-command-option=VALUE     	# Root command option
+    #       --help, -h                      	# Print this help
+    #   DESC
+    #
+    #   expect(output).to eq(expected)
+    #
+    #   output = capture_output { cli.call(arguments: %w[root-command sub-command --help]) }
+    #   expect(output).to eq(expected)
+    # end
+
+    # context 'works with params' do
+    #   it 'without params' do
+    #     error = capture_error { cli.call(arguments: %w[root-command sub-command]) }
+    #     expected = <<~DESC
+    #       ERROR: "rspec root-command sub-command" was called with no arguments
+    #       Usage: "rspec root-command sub-command ROOT_COMMAND_SUB_COMMAND_ARGUMENT"
+    #     DESC
+    #
+    #     expect(error).to eq(expected)
+    #   end
+
+    #   it 'with params' do
+    #     output = capture_output {
+    #       cli.call(arguments: ['root-command', 'sub-command', '"hello world"'])
+    #     }
+    #     expected = <<~DESC
+    #       I'm a root-command sub-command argument:"hello world"
+    #       I'm a root-command sub-command option:
+    #     DESC
+    #
+    #     expect(output).to eq(expected)
+    #   end
+    #
+    #   it 'with option using space' do
+    #     output = capture_output {
+    #       cli.call(arguments: [
+    #         'root-command',
+    #         'sub-command',
+    #         '"hello world"',
+    #         '--root-command-sub-command-option',
+    #         '"bye world"'
+    #       ])
+    #     }
+    #     expected = <<~DESC
+    #       I'm a root-command sub-command argument:"hello world"
+    #       I'm a root-command sub-command option:"bye world"
+    #     DESC
+    #
+    #     expect(output).to eq(expected)
+    #   end
+    #
+    #   it 'with option using equal sign' do
+    #     output = capture_output {
+    #       cli.call(arguments: [
+    #         'root-command',
+    #         'sub-command',
+    #         '"hello world"',
+    #         '--root-command-sub-command-option="bye world"'
+    #       ])
+    #     }
+    #     expected = <<~DESC
+    #       I'm a root-command sub-command argument:"hello world"
+    #       I'm a root-command sub-command option:"bye world"
+    #     DESC
+    #
+    #     expect(output).to eq(expected)
+    #   end
+    # end
+  end
 end
 # rubocop:enable Metrics/LineLength

--- a/spec/support/shared_examples/rendering.rb
+++ b/spec/support/shared_examples/rendering.rb
@@ -10,21 +10,22 @@ RSpec.shared_examples 'Rendering' do |cli|
     expected = <<~DESC
       Commands:
         #{cmd} assets [SUBCOMMAND]
-        #{cmd} callbacks DIR                       # Command with callbacks
-        #{cmd} console                             # Starts Foo console
+        #{cmd} callbacks DIR                                           # Command with callbacks
+        #{cmd} console                                                 # Starts Foo console
         #{cmd} db [SUBCOMMAND]
         #{cmd} destroy [SUBCOMMAND]
-        #{cmd} exec TASK [DIRS]                    # Execute a task
+        #{cmd} exec TASK [DIRS]                                        # Execute a task
         #{cmd} generate [SUBCOMMAND]
         #{cmd} greeting [RESPONSE]
-        #{cmd} hello                               # Print a greeting
-        #{cmd} new PROJECT                         # Generate a new Foo project
-        #{cmd} options-with-aliases                # Accepts options with aliases
-        #{cmd} routes                              # Print routes
-        #{cmd} server                              # Start Foo server (only for development)
+        #{cmd} hello                                                   # Print a greeting
+        #{cmd} new PROJECT                                             # Generate a new Foo project
+        #{cmd} options-with-aliases                                    # Accepts options with aliases
+        #{cmd} root-command [ARGUMENT|SUBCOMMAND]                      # Root command with arguments and subcommands
+        #{cmd} routes                                                  # Print routes
+        #{cmd} server                                                  # Start Foo server (only for development)
         #{cmd} sub [SUBCOMMAND]
         #{cmd} variadic [SUBCOMMAND]
-        #{cmd} version                             # Print Foo version
+        #{cmd} version                                                 # Print Foo version
     DESC
 
     expect(error).to eq(expected)
@@ -68,21 +69,22 @@ RSpec.shared_examples 'Rendering' do |cli|
     expected = <<~DESC
       Commands:
         #{cmd} assets [SUBCOMMAND]
-        #{cmd} callbacks DIR                       # Command with callbacks
-        #{cmd} console                             # Starts Foo console
+        #{cmd} callbacks DIR                                           # Command with callbacks
+        #{cmd} console                                                 # Starts Foo console
         #{cmd} db [SUBCOMMAND]
         #{cmd} destroy [SUBCOMMAND]
-        #{cmd} exec TASK [DIRS]                    # Execute a task
+        #{cmd} exec TASK [DIRS]                                        # Execute a task
         #{cmd} generate [SUBCOMMAND]
         #{cmd} greeting [RESPONSE]
-        #{cmd} hello                               # Print a greeting
-        #{cmd} new PROJECT                         # Generate a new Foo project
-        #{cmd} options-with-aliases                # Accepts options with aliases
-        #{cmd} routes                              # Print routes
-        #{cmd} server                              # Start Foo server (only for development)
+        #{cmd} hello                                                   # Print a greeting
+        #{cmd} new PROJECT                                             # Generate a new Foo project
+        #{cmd} options-with-aliases                                    # Accepts options with aliases
+        #{cmd} root-command [ARGUMENT|SUBCOMMAND]                      # Root command with arguments and subcommands
+        #{cmd} routes                                                  # Print routes
+        #{cmd} server                                                  # Start Foo server (only for development)
         #{cmd} sub [SUBCOMMAND]
         #{cmd} variadic [SUBCOMMAND]
-        #{cmd} version                             # Print Foo version
+        #{cmd} version                                                 # Print Foo version
     DESC
 
     expect(error).to eq(expected)
@@ -94,21 +96,22 @@ RSpec.shared_examples 'Rendering' do |cli|
     expected = <<~DESC
       Commands:
         #{cmd} assets [SUBCOMMAND]
-        #{cmd} callbacks DIR                       # Command with callbacks
-        #{cmd} console                             # Starts Foo console
+        #{cmd} callbacks DIR                                           # Command with callbacks
+        #{cmd} console                                                 # Starts Foo console
         #{cmd} db [SUBCOMMAND]
         #{cmd} destroy [SUBCOMMAND]
-        #{cmd} exec TASK [DIRS]                    # Execute a task
+        #{cmd} exec TASK [DIRS]                                        # Execute a task
         #{cmd} generate [SUBCOMMAND]
         #{cmd} greeting [RESPONSE]
-        #{cmd} hello                               # Print a greeting
-        #{cmd} new PROJECT                         # Generate a new Foo project
-        #{cmd} options-with-aliases                # Accepts options with aliases
-        #{cmd} routes                              # Print routes
-        #{cmd} server                              # Start Foo server (only for development)
+        #{cmd} hello                                                   # Print a greeting
+        #{cmd} new PROJECT                                             # Generate a new Foo project
+        #{cmd} options-with-aliases                                    # Accepts options with aliases
+        #{cmd} root-command [ARGUMENT|SUBCOMMAND]                      # Root command with arguments and subcommands
+        #{cmd} routes                                                  # Print routes
+        #{cmd} server                                                  # Start Foo server (only for development)
         #{cmd} sub [SUBCOMMAND]
         #{cmd} variadic [SUBCOMMAND]
-        #{cmd} version                             # Print Foo version
+        #{cmd} version                                                 # Print Foo version
     DESC
 
     expect(error).to eq(expected)

--- a/spec/support/shared_examples/subcommands.rb
+++ b/spec/support/shared_examples/subcommands.rb
@@ -136,4 +136,91 @@ RSpec.shared_examples 'Subcommands' do |cli|
       end
     end
   end
+
+  context 'works with root command' do
+    it 'shows help' do
+      output = capture_output { cli.call(arguments: %w[root-command sub-command -h]) }
+      expected = <<~DESC
+        Command:
+          rspec root-command sub-command
+
+        Usage:
+          rspec root-command sub-command ROOT_COMMAND_SUB_COMMAND_ARGUMENT
+
+        Description:
+          Root command sub command
+
+        Arguments:
+          ROOT_COMMAND_SUB_COMMAND_ARGUMENT	# REQUIRED Root command sub command argument
+
+        Options:
+          --root-command-sub-command-option=VALUE	# Root command sub command option
+          --help, -h                      	# Print this help
+      DESC
+
+      expect(output).to eq(expected)
+
+      output = capture_output { cli.call(arguments: %w[root-command sub-command --help]) }
+      expect(output).to eq(expected)
+    end
+
+    context 'works with params' do
+      it 'without params' do
+        error = capture_error { cli.call(arguments: %w[root-command sub-command]) }
+        expected = <<~DESC
+          ERROR: "rspec root-command sub-command" was called with no arguments
+          Usage: "rspec root-command sub-command ROOT_COMMAND_SUB_COMMAND_ARGUMENT"
+        DESC
+
+        expect(error).to eq(expected)
+      end
+
+      it 'with params' do
+        output = capture_output {
+          cli.call(arguments: ['root-command', 'sub-command', '"hello world"'])
+        }
+        expected = <<~DESC
+          I'm a root-command sub-command argument:"hello world"
+          I'm a root-command sub-command option:
+        DESC
+
+        expect(output).to eq(expected)
+      end
+
+      it 'with option using space' do
+        output = capture_output {
+          cli.call(arguments: [
+            'root-command',
+            'sub-command',
+            '"hello world"',
+            '--root-command-sub-command-option',
+            '"bye world"'
+          ])
+        }
+        expected = <<~DESC
+          I'm a root-command sub-command argument:"hello world"
+          I'm a root-command sub-command option:"bye world"
+        DESC
+
+        expect(output).to eq(expected)
+      end
+
+      it 'with option using equal sign' do
+        output = capture_output {
+          cli.call(arguments: [
+            'root-command',
+            'sub-command',
+            '"hello world"',
+            '--root-command-sub-command-option="bye world"'
+          ])
+        }
+        expected = <<~DESC
+          I'm a root-command sub-command argument:"hello world"
+          I'm a root-command sub-command option:"bye world"
+        DESC
+
+        expect(output).to eq(expected)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Overview
This PR adds possibility to register and use root command with arguments and subcommands.

## Details
- Add root command with params and subcommands handling.
- Improve `banner`, `usage` and commands description to show normal usage with params and subcommands.
- Add integration and unit tests for implemented logic.
- Add implemented feature description to docs.

## Example usage
```ruby
#!/usr/bin/env ruby
require "bundler/setup"
require "dry/cli"

module Foo
  module CLI
    module Commands
      extend Dry::CLI::Registry

      class Account < Dry::CLI::Command
        desc 'Information about account'

        argument :format, default: "short", values: %w[long short], desc: "Output format"

        def call(**options)
          puts "Information about account in #{options.fetch(:format)} format."
        end

        class Users < Dry::CLI::Command
          desc 'Information about account users'

          def call(**_options)
            puts "Information about account users."
          end
        end
      end

      register "account", Account
      register "account users", Account::Users
    end
  end
end

Dry::CLI.new(Foo::CLI::Commands).call
```
```
$ foo account -h
Command:
  foo account

Usage:
  foo account [FORMAT] | foo account SUBCOMMAND

Description:
  Information about account

Subcommands:
  users                         	# Information about account users

Arguments:
  FORMAT              	# Output format: (long/short)

Options:
  --help, -h                      	# Print this help
```
```
$ foo account
Information about account in short format.
```

```
$ foo account long
Information about account in long format.
```

```
$ foo account users
Information about account users.
```
